### PR TITLE
Use type parameter `T` for `WidgetTester.widget()` in unit tests

### DIFF
--- a/test/widgets/common/button_test.dart
+++ b/test/widgets/common/button_test.dart
@@ -51,7 +51,7 @@ void main() {
 
       expect(find.text(TextFixture.text), findsOneWidget);
 
-      final elevated = tester.widget(find.byType(Elevated)) as Elevated;
+      final elevated = tester.widget<Elevated>(find.byType(Elevated));
       expect(elevated.color, releasedColor);
       expect(elevated.border, releasedBorder);
     },
@@ -78,7 +78,7 @@ void main() {
 
       expect(find.text(TextFixture.text), findsOneWidget);
 
-      final elevated = tester.widget(find.byType(Elevated)) as Elevated;
+      final elevated = tester.widget<Elevated>(find.byType(Elevated));
       expect(elevated.color, pressedColor);
       expect(elevated.border, pressedBorder);
     },
@@ -107,7 +107,7 @@ void main() {
 
       expect(find.text(testText), findsOneWidget);
 
-      final elevated = tester.widget(find.byType(Elevated)) as Elevated;
+      final elevated = tester.widget<Elevated>(find.byType(Elevated));
       expect(
         elevated.color,
         IntelliCookTheme.primaryPalette.getColor(Button.releasedPaletteTone),
@@ -142,7 +142,7 @@ void main() {
 
       expect(find.text(testText), findsOneWidget);
 
-      final elevated = tester.widget(find.byType(Elevated)) as Elevated;
+      final elevated = tester.widget<Elevated>(find.byType(Elevated));
       expect(
         elevated.color,
         IntelliCookTheme.primaryPalette.getColor(Button.pressedPaletteTone),
@@ -170,7 +170,7 @@ void main() {
 
       expect(find.text(testText), findsOneWidget);
 
-      final elevated = tester.widget(find.byType(Elevated)) as Elevated;
+      final elevated = tester.widget<Elevated>(find.byType(Elevated));
       expect(
         elevated.color,
         theme.colorScheme.surfaceContainerLowest
@@ -209,7 +209,7 @@ void main() {
 
       expect(find.text(testText), findsOneWidget);
 
-      final elevated = tester.widget(find.byType(Elevated)) as Elevated;
+      final elevated = tester.widget<Elevated>(find.byType(Elevated));
       expect(
         elevated.color,
         theme.colorScheme.surfaceContainerLow

--- a/test/widgets/common/elevated_test.dart
+++ b/test/widgets/common/elevated_test.dart
@@ -47,7 +47,7 @@ void main() {
 
       expect(find.text(TextFixture.text), findsOneWidget);
 
-      final container = tester.widget(find.byType(Container)) as Container;
+      final container = tester.widget<Container>(find.byType(Container));
 
       final decoration = container.decoration as BoxDecoration;
       expect(decoration.border, border);
@@ -93,7 +93,7 @@ void main() {
       expect(find.text(TextFixture.text), findsOneWidget);
 
       final container =
-          tester.widget(find.byType(AnimatedContainer)) as AnimatedContainer;
+          tester.widget<AnimatedContainer>(find.byType(AnimatedContainer));
 
       final decoration = container.decoration as BoxDecoration;
       expect(decoration.border, border);
@@ -126,7 +126,7 @@ void main() {
 
       expect(find.text(TextFixture.text), findsOneWidget);
 
-      final container = tester.widget(find.byType(Container)) as Container;
+      final container = tester.widget<Container>(find.byType(Container));
 
       final decoration = container.decoration as BoxDecoration;
       expect(decoration.border, border);
@@ -157,7 +157,7 @@ void main() {
 
       expect(find.text(TextFixture.text), findsOneWidget);
 
-      final container = tester.widget(find.byType(Container)) as Container;
+      final container = tester.widget<Container>(find.byType(Container));
 
       final decoration = container.decoration as BoxDecoration;
       expect(decoration.border, border);

--- a/test/widgets/common/panel_test.dart
+++ b/test/widgets/common/panel_test.dart
@@ -34,7 +34,7 @@ void main() {
 
       expect(find.text(TextFixture.text), findsOneWidget);
 
-      final container = tester.widget(find.byType(Container)) as Container;
+      final container = tester.widget<Container>(find.byType(Container));
 
       final decoration = container.decoration as BoxDecoration;
       expect(decoration.color, color);
@@ -63,7 +63,7 @@ void main() {
 
       expect(find.text(TextFixture.text), findsOneWidget);
 
-      final container = tester.widget(find.byType(Container)) as Container;
+      final container = tester.widget<Container>(find.byType(Container));
 
       final decoration = container.decoration as BoxDecoration;
       expect(


### PR DESCRIPTION
Use type parameter `T` for `WidgetTester.widget()` in unit tests to make it more concise