### PR TITLE
Extract button defaults to static consts

### DIFF
--- a/lib/widgets/common/button.dart
+++ b/lib/widgets/common/button.dart
@@ -16,6 +16,9 @@ class Button extends StatefulWidget {
     this.releasedColor,
     this.pressedBorder,
     this.releasedBorder,
+    this.constraints = defaultConstraints,
+    this.padding = defaultPadding,
+    this.animatedElevatedArgs = defaultAnimatedElevatedArgs,
     this.child,
   });
 
@@ -27,6 +30,9 @@ class Button extends StatefulWidget {
     this.onStateChange,
     this.pressedBorder,
     this.releasedBorder,
+    this.constraints = defaultConstraints,
+    this.padding = defaultPadding,
+    this.animatedElevatedArgs = defaultAnimatedElevatedArgs,
     Color? pressedColor,
     Color? releasedColor,
     this.child,
@@ -43,6 +49,9 @@ class Button extends StatefulWidget {
     this.onStateChange,
     this.pressedColor,
     this.releasedColor,
+    this.constraints = defaultConstraints,
+    this.padding = defaultPadding,
+    this.animatedElevatedArgs = defaultAnimatedElevatedArgs,
     BoxBorder? pressedBorder,
     BoxBorder? releasedBorder,
     this.child,
@@ -59,6 +68,22 @@ class Button extends StatefulWidget {
               width: secondaryBorderWidth,
             );
 
+  static const minHeight = 40.0;
+  static const minWidth = 50.0;
+  static const pressedPaletteTone = 70;
+  static const releasedPaletteTone = 80;
+  static const secondaryBorderWidth = 1.5;
+  static const secondaryOpacity = 0.5;
+  static const defaultConstraints = BoxConstraints(
+    minHeight: Button.minHeight,
+    minWidth: Button.minWidth,
+  );
+  static const defaultPadding = EdgeInsets.symmetric(
+    vertical: SpacingConsts.s,
+    horizontal: SpacingConsts.m,
+  );
+  static const defaultAnimatedElevatedArgs = AnimatedElevatedArgs();
+
   final ClickableOnClickCallback? onClick;
   final ClickableOnPressCallback? onPress;
   final ClickableOnReleaseCallback? onRelease;
@@ -67,14 +92,10 @@ class Button extends StatefulWidget {
   final Color? releasedColor;
   final BoxBorder? pressedBorder;
   final BoxBorder? releasedBorder;
+  final BoxConstraints? constraints;
+  final EdgeInsets? padding;
+  final AnimatedElevatedArgs? animatedElevatedArgs;
   final Widget? child;
-
-  static const minHeight = 40.0;
-  static const minWidth = 50.0;
-  static const pressedPaletteTone = 70;
-  static const releasedPaletteTone = 80;
-  static const secondaryBorderWidth = 1.5;
-  static const secondaryOpacity = 0.5;
 
   @override
   State<Button> createState() => _ButtonState();
@@ -104,17 +125,11 @@ class _ButtonState extends State<Button> {
         widget.onStateChange?.call(isPressed);
       },
       child: Elevated.low(
-        constraints: const BoxConstraints(
-          minHeight: Button.minHeight,
-          minWidth: Button.minWidth,
-        ),
-        padding: const EdgeInsets.symmetric(
-          vertical: SpacingConsts.s,
-          horizontal: SpacingConsts.m,
-        ),
+        constraints: widget.constraints,
+        padding: widget.padding,
         color: isPressed ? pressedColor : releasedColor,
         border: isPressed ? widget.pressedBorder : widget.releasedBorder,
-        animatedElevatedArgs: const AnimatedElevatedArgs(),
+        animatedElevatedArgs: widget.animatedElevatedArgs,
         insetShadow: isPressed,
         child: widget.child,
       ),

--- a/test/widgets/common/button_test.dart
+++ b/test/widgets/common/button_test.dart
@@ -40,12 +40,21 @@ void main() {
       const releasedColor = Colors.blue;
       final pressedBorder = Border.all(color: Colors.green);
       final releasedBorder = Border.all(color: Colors.orange);
+      const constraints = BoxConstraints.tightFor(width: 100, height: 100);
+      const padding = EdgeInsets.all(10);
+      const animatedElevatedArgs = AnimatedElevatedArgs(
+        duration: Duration(milliseconds: 10),
+        curve: Curves.linear,
+      );
 
       await tester.pumpWidget(Button(
         pressedColor: pressedColor,
         releasedColor: releasedColor,
         pressedBorder: pressedBorder,
         releasedBorder: releasedBorder,
+        constraints: constraints,
+        padding: padding,
+        animatedElevatedArgs: animatedElevatedArgs,
         child: TextFixture.widget(),
       ));
 
@@ -54,6 +63,9 @@ void main() {
       final elevated = tester.widget<Elevated>(find.byType(Elevated));
       expect(elevated.color, releasedColor);
       expect(elevated.border, releasedBorder);
+      expect(elevated.constraints, constraints);
+      expect(elevated.padding, padding);
+      expect(elevated.animatedElevatedArgs, animatedElevatedArgs);
     },
   );
 
@@ -64,12 +76,21 @@ void main() {
       const releasedColor = Colors.blue;
       final pressedBorder = Border.all(color: Colors.green);
       final releasedBorder = Border.all(color: Colors.orange);
+      const constraints = BoxConstraints.tightFor(width: 100, height: 100);
+      const padding = EdgeInsets.all(10);
+      const animatedElevatedArgs = AnimatedElevatedArgs(
+        duration: Duration(milliseconds: 10),
+        curve: Curves.linear,
+      );
 
       await tester.pumpWidget(Button(
         pressedColor: pressedColor,
         releasedColor: releasedColor,
         pressedBorder: pressedBorder,
         releasedBorder: releasedBorder,
+        constraints: constraints,
+        padding: padding,
+        animatedElevatedArgs: animatedElevatedArgs,
         child: TextFixture.widget(),
       ));
 
@@ -81,11 +102,14 @@ void main() {
       final elevated = tester.widget<Elevated>(find.byType(Elevated));
       expect(elevated.color, pressedColor);
       expect(elevated.border, pressedBorder);
+      expect(elevated.constraints, constraints);
+      expect(elevated.padding, padding);
+      expect(elevated.animatedElevatedArgs, animatedElevatedArgs);
     },
   );
 
   testWidgets(
-    'Primary button shows child with defaults when released',
+    'Primary button shows child with arguments and defaults when released',
     (WidgetTester tester) async {
       final context = MockBuildContext();
       final theme = IntelliCookTheme.theme(context, Brightness.light);
@@ -113,11 +137,14 @@ void main() {
         IntelliCookTheme.primaryPalette.getColor(Button.releasedPaletteTone),
       );
       expect(elevated.border, releasedBorder);
+      expect(elevated.constraints, Button.defaultConstraints);
+      expect(elevated.padding, Button.defaultPadding);
+      expect(elevated.animatedElevatedArgs, Button.defaultAnimatedElevatedArgs);
     },
   );
 
   testWidgets(
-    'Primary button shows child with defaults when pressed',
+    'Primary button shows child with arguments and defaults when pressed',
     (WidgetTester tester) async {
       final context = MockBuildContext();
       final theme = IntelliCookTheme.theme(context, Brightness.light);
@@ -148,11 +175,14 @@ void main() {
         IntelliCookTheme.primaryPalette.getColor(Button.pressedPaletteTone),
       );
       expect(elevated.border, pressedBorder);
+      expect(elevated.constraints, Button.defaultConstraints);
+      expect(elevated.padding, Button.defaultPadding);
+      expect(elevated.animatedElevatedArgs, Button.defaultAnimatedElevatedArgs);
     },
   );
 
   testWidgets(
-    'Secondary button shows child with defaults when released',
+    'Secondary button shows child with arguments and defaults when released',
     (WidgetTester tester) async {
       final context = MockBuildContext();
       final theme = IntelliCookTheme.theme(context, Brightness.light);
@@ -184,11 +214,14 @@ void main() {
           width: Button.secondaryBorderWidth,
         ),
       );
+      expect(elevated.constraints, Button.defaultConstraints);
+      expect(elevated.padding, Button.defaultPadding);
+      expect(elevated.animatedElevatedArgs, Button.defaultAnimatedElevatedArgs);
     },
   );
 
   testWidgets(
-    'Secondary button shows child with defaults when pressed',
+    'Secondary button shows child with arguments and defaults when pressed',
     (WidgetTester tester) async {
       final context = MockBuildContext();
       final theme = IntelliCookTheme.theme(context, Brightness.light);
@@ -223,6 +256,9 @@ void main() {
           width: Button.secondaryBorderWidth,
         ),
       );
+      expect(elevated.constraints, Button.defaultConstraints);
+      expect(elevated.padding, Button.defaultPadding);
+      expect(elevated.animatedElevatedArgs, Button.defaultAnimatedElevatedArgs);
     },
   );
 


### PR DESCRIPTION
To stay consistent with all `const` default values across all widget classes, they should be `static const` of the class of the widget. `Button` is no exception.

Only if the default values are `final`, then they should be generated in `build()` method. Even if the variable is generated in `build()`, if there is any `const` used in the process, they should be `static const` of the class.